### PR TITLE
Splitting out the about page and adding privacy and OSS stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Are you interested in making things better? Then by all means contribute! You ca
 
 ### Running Locally
 
-This system can be run _alomst_ entirely locally. The only piece that can't be run locally is the regulations.gov API. But you can easily [sign up for an API key](https://api.data.gov/signup/) yourself in order to hit the API. You could also create a mock API for development if you like.
+This system can be run _almost_ entirely locally. The only piece that can't be run locally is the regulations.gov API. But you can easily [sign up for an API key](https://api.data.gov/signup/) yourself in order to hit the API. You could also create a mock API for development if you like.
 
 #### Environment Setup
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const session = require('express-session')
 
 // All the routes
 const home = require('./routes/home')
+const about = require('./routes/about')
 const dockets = require('./routes/docket')
 const documents = require('./routes/document')
 
@@ -73,6 +74,7 @@ app.use((req, res, next) => {
 })
 
 app.use('/', home)
+app.use('/about', about)
 app.use('/docket', dockets)
 app.use('/document', documents)
 

--- a/src/routes/about.js
+++ b/src/routes/about.js
@@ -1,0 +1,14 @@
+const express = require('express')
+const router = express.Router()
+
+
+router.get('/', (req, res) => {
+    res.render('about', {
+        page: 'about',
+        title: 'About US Gov Regs Explorer',
+        user: req.session.user || null
+    })
+})
+
+
+module.exports = router

--- a/views/about.pug
+++ b/views/about.pug
@@ -66,3 +66,24 @@ block content
                     | Curious to see how this is built? (It's not fancy, I warn you...)
 
                 a.usa-button.usa-button--big(href='https://github.com/jakerella/usgov-regs') Explore Code on GitHub
+
+    article.usa-section
+        section.grid-container
+            h3.font-heading-xl.margin-y-0 Legal Things
+            p.usa-intro
+                | This site and all functionality is presented as-is with no warranty. In other words,
+                | I hope it works for you, but I make no guarantees, and the whole thing could disappear 
+                | at any time because this is an open source side project and not a business.
+            
+            p.usa-intro
+                | The code for this site is provided completely free and open source at
+                a(href='https://github.com/jakerella/usgov-regs' target='_blank') github.com/jakerella/usgov-regs
+                | and is published under the 
+                a(href='https://opensource.org/licenses/MIT' target='_blank') MIT license
+                | . I encourage anyone interested to run a version of this site on their own or to make any 
+                | modifications they wish.
+            
+            p.usa-intro
+                | The privacy policy of this site is that 100% of the data you store, enter, or access on this 
+                | site is private and will never be shared with anyone outside of the maintainers of this site 
+                | without your (the user's) express permission and only by request of the relevant user.


### PR DESCRIPTION
## What is the problem being solved?

Needed a little legal info in here

## How have you solved the problem?

Adding legal stuff to the about page and breaking it to its own route

